### PR TITLE
Use child process.fork

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -31,10 +31,11 @@ class Configuration {
 
   async save() {
     return new Promise((resolve, reject) => {
-      fs.writeFile(this.configFile, JSON.stringify(this.configObject), (err) => {
-        if (err) return reject(err)
-        resolve()
-      })
+      if (this.configFile)
+        fs.writeFile(this.configFile, JSON.stringify(this.configObject), (err) => {
+          if (err) return reject(err)
+          resolve()
+        })
     })
   }
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,7 +32,7 @@ class Configuration {
   async save() {
     return new Promise((resolve, reject) => {
       if (this.configFile)
-        fs.writeFile(this.configFile, JSON.stringify(this.configObject), (err) => {
+        fs.writeFile(this.configFile, JSON.stringify(this.config()), (err) => {
           if (err) return reject(err)
           resolve()
         })

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -1,0 +1,37 @@
+function repeat(char, times) {
+  let string = ''
+
+  for (let i = 0; i < times; i++)
+    string += char
+
+  return string
+}
+
+function color(text, color) {
+  switch(color) {
+    case 'red':
+      return `\x1b[0m${text}\x1b[0m`
+    case 'green':
+      return `\x1b[32m${text}\x1b[0m`
+    default:
+      throw `Unkown color: ${color}`
+  }
+}
+
+function suiteBuilder(depth) {
+  depth = depth || 0
+
+  return function describe(title, suite) {
+    console.log(`${repeat('  ', depth)}${title}`)
+    suite(function it(name, body) {
+      try {
+        body()
+        console.log(color(`${repeat('  ', depth + 1)}Passed: ${name}`, 'green'))
+      } catch (e) {
+        console.log(color(`${repeat('  ', depth + 1)}Failed: ${name}`, 'red'), e)
+      }
+    }, suiteBuilder(depth + 1))
+  }
+}
+
+module.exports = suiteBuilder(0)

--- a/rx-index.js
+++ b/rx-index.js
@@ -4,12 +4,10 @@ const app = express();
 const http = require('http').Server(app);
 const bp = require('body-parser');
 const io = require('socket.io')(http);
-const { spawn } = require('child_process');
-const { exec } = require('child_process');
+const { spawn, exec, fork } = require('child_process');
 const ip = require('./lib/getIp')
 const Configuration = require('./lib/configuration')
 const Devices = require('./lib/autoDiscovery')
-const ChildProcess = require('./lib/childProcess')
 const port = process.env.port || 5000;
 
 app.use(bp.json())
@@ -19,20 +17,19 @@ app.use(expressLayouts);
 app.set('layout', 'application');
 app.set('view engine', 'ejs');
 
-var configFile = new Configuration('./config/rx-config.json')
-var config = {
-  name : configFile.get('name'),
-  type : configFile.get('type'),
-  ip : configFile.get('ip')
-}
+var config = new Configuration('./config/rx-config.json')
 
-var start = new ChildProcess('receive.js')
-var devices = new Devices(config)
+// We can just use `fork()` instead of pm2, it provides a way for use to
+// send data to the child_process!
+var receive = fork('./child_processes/receive.js')
+receive.send({ type: 'start', config: config.config() })
+receive.on('message', packet => console.log(packet))
 
-if (config.ip != ip) {
+var devices = new Devices(config.config())
+
+if (config.get('ip') != ip) {
     // exec(`echo ${config.rootPassword} | sudo -S ifconfig ${local.interface} ${config.ipAddress}` , (err, stdout, stderr) => {console.log(stdout)} );
 }
-
 
 devices.listenForNewDevices( (device) => {
   console.log("New " + device.type + " Device:" , device)
@@ -47,33 +44,26 @@ devices.listenForNewDevices( (device) => {
 
 })
 
-
-start.childProcess(function (childProcess) {
-    console.log("Started Child Process:", childProcess)
-})
-
-
 // Allow User configuration
 io.on('connection', (socket) => {
   console.log('user connected');
 
-  socket.emit('config', configFile.configObject)
+  socket.emit('config', config.config())
 
   socket.on('volume', (input) => {
-    configFile.debouncedSet('volume', input)
+    config.debouncedSet('volume', input)
     spawn('amixer', ['set', 'Headphone', `${input}%`])
   })
 
   socket.on('source', async (input) => {
-    await configFile.set('sourcePort', input)
+    await config.set('sourcePort', input)
     console.log(input)
     pm2.restart("listen")
   })
 
   socket.on('ip', async (input) => {
-    var port = input
-    await configFile.set('ipAddress', input)
-    socket.emit('newConfig', config)
+    await config.set('ipAddress', input)
+    socket.emit('newConfig', config.config())
     pm2.restart('index')
   })
 
@@ -93,7 +83,6 @@ io.on('connection', (socket) => {
 app.get('/', function (req, res) {
   res.render('configure-rx.ejs');
 });
-
 
 //
 // Starting the App

--- a/test/lib/configuration.js
+++ b/test/lib/configuration.js
@@ -1,0 +1,48 @@
+const describe = require('../../lib/describe')
+const assert = require('assert')
+const Configuration = require('../../lib/configuration')
+const fs = require('fs')
+
+describe('Configuration', (it, describe) => {
+  it('should create a new configuration object', () => {
+    let config = new Configuration()
+  })
+
+  describe('.config()', (it, when) => {
+    when("the config file doesn't exist", (it) => {
+      it('should be an empty object', () => {
+        let config = new Configuration()
+        assert(JSON.stringify(config.config()) === '{}')
+      })
+    })
+
+    when('the config file does exist', (it) => {
+      const testConfig = { test: true }
+      const testConfigName = './test-conf.json'
+      fs.writeFileSync(testConfigName, JSON.stringify(testConfig))
+
+      it('should have valid keys from the test config', () => {
+        let config = new Configuration(testConfigName)
+        assert(config.config().test)
+      })
+     
+      fs.unlinkSync(testConfigName)
+    })
+  })
+
+  describe('.get(key)', (it) => {
+    it('should return the value for the given key', () => {
+      let config = new Configuration()
+      config.set('test', true)
+      assert(config.get('test'))
+    })
+  })
+
+  describe('.set(key, value)', (it) => {
+    it('should set the given key to the value', () => {
+      let config = new Configuration()
+      config.set('test', false)
+      assert(config.get('test') === false)
+    })
+  })
+})


### PR DESCRIPTION
I'm trying out moving `rx-index.js` over to use Configuration and using child_process.fork to run and manage `child_process/receive.js`.


I installed roc on my mac with: https://gavv.github.io/articles/roc-tutorial/#macos

and I adapted receive to check if the current machine is a linux machine and only use the alsa backend then, otherwise it uses the default (coreaudio on macos). This lets us run rx-index on our macs.
